### PR TITLE
Compute false positive probability for whole client query

### DIFF
--- a/psi_cardinality/bloom_filter.cpp
+++ b/psi_cardinality/bloom_filter.cpp
@@ -144,7 +144,8 @@ std::vector<int64_t> BloomFilter::Hash(const std::string& x) const {
       context_->CreateBigNum(context_->Sha256String(absl::StrCat(1, x)))
           .Mod(bn_num_bits)
           .ToIntValue()
-          .ValueOrDie();  // ValueOrDie is safe here since bn_num_bits fits in an int64.
+          .ValueOrDie();  // ValueOrDie is safe here since bn_num_bits fits in
+                          // an int64.
   const int64_t h2 =
       context_->CreateBigNum(context_->Sha256String(absl::StrCat(2, x)))
           .Mod(bn_num_bits)

--- a/psi_cardinality/psi_cardinality_client_test.cpp
+++ b/psi_cardinality/psi_cardinality_client_test.cpp
@@ -53,8 +53,9 @@ TEST_F(PSICardinalityClientTest, TestCorrectness) {
   }
 
   // Insert server elements into Bloom filter.
-  PSI_ASSERT_OK_AND_ASSIGN(auto bloom_filter,
-                           BloomFilter::Create(fpr, num_server_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(
+      auto bloom_filter,
+      BloomFilter::Create(fpr / num_client_elements, num_server_elements));
   PSI_ASSERT_OK_AND_ASSIGN(
       auto server_ec_cipher,
       ::private_join_and_compute::ECCommutativeCipher::CreateWithNewKey(

--- a/psi_cardinality/psi_cardinality_server.h
+++ b/psi_cardinality/psi_cardinality_server.h
@@ -44,9 +44,9 @@ class PSICardinalityServer {
       const std::string& key_bytes);
 
   // Creates a setup message from the server's dataset to be sent to the client.
-  // The setup message is a JSON-encoded Bloom filter with the given
-  // false-positive rate `fpr` containing H(x)^s for each element x in `inputs`,
-  // where s is the server's secret key. The message has the following form:
+  // The setup message is a JSON-encoded Bloom filter containing H(x)^s for each
+  // element x in `inputs`, where s is the server's secret key. The message has
+  // the following form:
   //
   //   {
   //     "num_hash_functions": <int>,
@@ -54,10 +54,13 @@ class PSICardinalityServer {
   //   }
   //
   // `bits` is encoded as Base64.
+  // The false-positive rate `fpr` is the probability that any query of size
+  // `num_client_inputs` will result in a false positive.
   //
   // Returns INTERNAL if encryption fails.
   StatusOr<std::string> CreateSetupMessage(
-      double fpr, absl::Span<const std::string> inputs) const;
+      double fpr, int64_t num_client_inputs,
+      absl::Span<const std::string> inputs) const;
 
   // Processes a client query and returns the corresponding server response to
   // be sent to the client. For each encrytped element H(x)^c in the decoded

--- a/psi_cardinality/psi_cardinality_server_test.cpp
+++ b/psi_cardinality/psi_cardinality_server_test.cpp
@@ -52,8 +52,9 @@ TEST_F(PSICardinalityServerTest, TestCorrectness) {
   }
 
   // Run Server setup.
-  PSI_ASSERT_OK_AND_ASSIGN(auto server_setup,
-                           server_->CreateSetupMessage(fpr, server_elements));
+  PSI_ASSERT_OK_AND_ASSIGN(
+      auto server_setup,
+      server_->CreateSetupMessage(fpr, num_client_elements, server_elements));
 
   // Create Client request.
   PSI_ASSERT_OK_AND_ASSIGN(auto client_request,


### PR DESCRIPTION
Before, the bloom filter false positive probability was given for a single query, which is confusing since in PSI-CA, we always want to check multiple elements. The server setup now adjusts this probability to account for the client query size.